### PR TITLE
Add model-specific prompt defaults

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -2,9 +2,10 @@ import itertools
 import json
 import logging
 import random
+import re
 import time
 from collections import defaultdict
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import numpy as np
 import torch
@@ -76,6 +77,10 @@ def simple_evaluate(
     fewshot_random_seed: int = 1234,
     confirm_run_unsafe_code: bool = False,
     metadata: Optional[dict] = None,
+    description_override: Optional[str] = None,
+    gen_prefix_override: Optional[str] = None,
+    chat_template_fn: Optional[Callable] = None,
+    answer_regex_override: Optional[str] = None,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -140,6 +145,14 @@ def simple_evaluate(
         Random seed for fewshot sampler random generator. If set to None, the seed of generator will be set to None.
     :param metadata: dict
         Additional metadata to be added to the task manager. Will get passed to the download function of the task.
+    :param description_override: str
+        Optional description string that overrides task descriptions.
+    :param gen_prefix_override: str
+        Optional generation prefix to apply to all tasks.
+    :param chat_template_fn: Callable
+        Custom chat template function to override the model's implementation.
+    :param answer_regex_override: str
+        Optional regex used to extract the final answer from model outputs.
 
     return
         Dictionary of results
@@ -243,6 +256,9 @@ def simple_evaluate(
         eval_logger.info("Using pre-initialized model")
         lm = model
 
+    if chat_template_fn is not None:
+        lm.apply_chat_template = chat_template_fn
+
     if use_cache is not None:
         eval_logger.info(f"Using cache at {use_cache + '_rank' + str(lm.rank) + '.db'}")
         lm = lm_eval.api.model.CachingLM(
@@ -318,6 +334,32 @@ def simple_evaluate(
                         task_obj.set_config(key="num_fewshot", value=0)
                 # fewshot_random_seed set for tasks, even with a default num_fewshot (e.g. in the YAML file)
                 task_obj.set_fewshot_seed(seed=fewshot_random_seed)
+                if description_override is not None:
+                    task_obj.set_config(key="description", value=description_override)
+                if gen_prefix_override is not None:
+                    task_obj.set_config(key="gen_prefix", value=gen_prefix_override)
+                if (
+                    answer_regex_override is not None
+                    and task_obj.get_config("output_type") == "generate_until"
+                ):
+                    original_process_results = task_obj.process_results
+                    regex = re.compile(answer_regex_override)
+
+                    def wrapped_process(
+                        doc, results, _regex=regex, _orig=original_process_results
+                    ):
+                        processed = []
+                        for r in results:
+                            match = _regex.search(r)
+                            if match:
+                                processed.append(
+                                    match.group(1) if match.groups() else match.group(0)
+                                )
+                            else:
+                                processed.append(r)
+                        return _orig(doc, processed)
+
+                    task_obj.process_results = wrapped_process
 
                 adjusted_task_dict[task_name] = task_obj
 
@@ -333,7 +375,11 @@ def simple_evaluate(
             model_source=model,
             model_args=model_args,
             system_instruction=system_instruction,
-            chat_template=lm.chat_template(apply_chat_template)
+            chat_template=(
+                lm.chat_template(apply_chat_template)
+                if chat_template_fn is None
+                else chat_template_fn
+            )
             if apply_chat_template
             else None,
             fewshot_as_multiturn=fewshot_as_multiturn,
@@ -354,6 +400,8 @@ def simple_evaluate(
         fewshot_as_multiturn=fewshot_as_multiturn,
         verbosity=verbosity,
         confirm_run_unsafe_code=confirm_run_unsafe_code,
+        chat_template_fn=chat_template_fn,
+        answer_regex_override=answer_regex_override,
     )
     if verbosity is not None:
         setup_logging(verbosity=verbosity)
@@ -417,6 +465,8 @@ def evaluate(
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
     confirm_run_unsafe_code: bool = False,
+    chat_template_fn: Optional[Callable] = None,
+    answer_regex_override: Optional[str] = None,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -451,6 +501,10 @@ def evaluate(
         Verbosity level for logging
     :param confirm_run_unsafe_code: bool
         Whether to confirm running tasks marked as unsafe.
+    :param chat_template_fn: Callable
+        Optional chat template function to apply instead of the model's default.
+    :param answer_regex_override: str
+        Optional regex used to extract the final answer from model outputs.
     :return
         Dictionary of results
     """
@@ -520,9 +574,13 @@ def evaluate(
             system_instruction=system_instruction,
             apply_chat_template=bool(apply_chat_template),
             fewshot_as_multiturn=fewshot_as_multiturn,
-            chat_template=getattr(lm, "apply_chat_template")
-            if apply_chat_template
-            else None,
+            chat_template=(
+                chat_template_fn
+                if apply_chat_template and chat_template_fn is not None
+                else getattr(lm, "apply_chat_template")
+                if apply_chat_template
+                else None
+            ),
             tokenizer_name=getattr(lm, "tokenizer_name", "")
             if apply_chat_template
             else "",

--- a/lm_eval/models/prompt_defaults.py
+++ b/lm_eval/models/prompt_defaults.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional
+
+
+def default_chat_template(
+    messages: List[Dict[str, str]], add_generation_prompt: bool = True
+) -> str:
+    """A simple OpenAI-style chat template used as fallback."""
+    chat = ""
+    for m in messages:
+        chat += f"<|{m['role']}|>{m['content']}"
+    if add_generation_prompt:
+        chat += "<|assistant|>"
+    return chat
+
+
+# Model specific descriptions
+qwen25_math_description = (
+    """You are a helpful assistant specialized in solving math problems."""
+)
+qwen2_math_description = """You are a helpful assistant specialized in mathematics."""
+deepseek_math_description = """You are a math tutor that explains step by step."""
+
+gemma_9b_description = """You are a helpful assistant."""
+gemma_27b_description = """You are a helpful assistant."""
+
+
+# Chat template examples (can be replaced with model specific ones)
+def qwen_chat_template(
+    messages: List[Dict[str, str]], add_generation_prompt: bool = True
+) -> str:
+    chat = ""
+    for m in messages:
+        role = m["role"]
+        chat += f"<|im_start|>{role}\n{m['content']}<|im_end|>"
+    if add_generation_prompt:
+        chat += "<|im_start|>assistant\n"
+    return chat
+
+
+def gemma_chat_template(
+    messages: List[Dict[str, str]], add_generation_prompt: bool = True
+) -> str:
+    chat = ""
+    for m in messages:
+        chat += f"<|start|>{m['role']}|{m['content']}<|end|>"
+    if add_generation_prompt:
+        chat += "<|start|>assistant|"
+    return chat
+
+
+MODEL_PROMPT_CONFIGS: Dict[str, Dict[str, object]] = {
+    "Qwen/Qwen2.5-Math-7B-Instruct": {
+        "description": qwen25_math_description,
+        "system_instruction": qwen25_math_description,
+        "apply_chat_template": True,
+        "chat_template": qwen_chat_template,
+        "gen_prefix": "",
+        "answer_regex": r"\\boxed\{([^}]*)\}",
+    },
+    "Qwen/Qwen2-Math-7B-Instruct": {
+        "description": qwen2_math_description,
+        "system_instruction": qwen2_math_description,
+        "apply_chat_template": True,
+        "chat_template": qwen_chat_template,
+        "gen_prefix": "",
+        "answer_regex": r"\\boxed\{([^}]*)\}",
+    },
+    "deepseek-math-7b-instruct": {
+        "description": deepseek_math_description,
+        "system_instruction": deepseek_math_description,
+        "apply_chat_template": True,
+        "chat_template": default_chat_template,
+        "gen_prefix": "",
+        "answer_regex": r"\\boxed\{([^}]*)\}",
+    },
+    "google/gemma-2-9b-it": {
+        "description": gemma_9b_description,
+        "system_instruction": gemma_9b_description,
+        "apply_chat_template": True,
+        "chat_template": gemma_chat_template,
+        "gen_prefix": "<bos>",
+        "answer_regex": r"\\boxed\{([^}]*)\}",
+    },
+    "google/gemma-2-27b-it": {
+        "description": gemma_27b_description,
+        "system_instruction": gemma_27b_description,
+        "apply_chat_template": True,
+        "chat_template": gemma_chat_template,
+        "gen_prefix": "<bos>",
+        "answer_regex": r"\\boxed\{([^}]*)\}",
+    },
+}
+
+
+def get_prompt_config(model_name: str) -> Optional[Dict[str, object]]:
+    model_name = model_name.lower()
+    for key, cfg in MODEL_PROMPT_CONFIGS.items():
+        if key.lower() in model_name:
+            return cfg
+    return None


### PR DESCRIPTION
## Summary
- introduce `prompt_defaults.py` to store per-model prompt settings
- load and apply these defaults in the CLI
- extend evaluator to override descriptions, prefixes, chat templates and now extract `\boxed{}` answers

## Testing
- `ruff format lm_eval/evaluator.py lm_eval/__main__.py lm_eval/models/prompt_defaults.py`
- `pytest -q` *(fails: couldn't reach 'allenai/ai2_arc' on the Hub due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68623ff314b8832789611b00a9977656